### PR TITLE
upgrade spark redis

### DIFF
--- a/emr-redis/pom.xml
+++ b/emr-redis/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>com.redislabs</groupId>
-            <artifactId>spark-redis</artifactId>
+            <artifactId>spark-redis_${scala.binary.version}</artifactId>
         </dependency>
 
         <dependency>
@@ -74,7 +74,7 @@
                     <artifactSet>
                         <includes>
                             <include>redis.clients:jedis</include>
-                            <include>com.redislabs:spark-redis</include>
+                            <include>com.redislabs:spark-redis_${scala.binary.version}</include>
                         </includes>
                     </artifactSet>
                 </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,7 @@
         <protobuf.version>2.5.0</protobuf.version>
         <hbase.version>1.4.9</hbase.version>
         <hbase.mr.version>2.0.4</hbase.mr.version>
-        <spark.redis.version>2.4.0</spark.redis.version>
+        <spark.redis.version>2.4.2</spark.redis.version>
         <phoenix.version>5.0.0-HBase-2.0</phoenix.version>
         <json4s.jackson.version>3.5.3</json4s.jackson.version>
         <curator.version>4.2.0</curator.version>
@@ -534,7 +534,7 @@
 
             <dependency>
                 <groupId>com.redislabs</groupId>
-                <artifactId>spark-redis</artifactId>
+                <artifactId>spark-redis_${scala.binary.version}</artifactId>
                 <version>${spark.redis.version}</version>
             </dependency>
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

in current version, scala-2.11 is imported in spark-redis library which is not we want. in this PR, I upgrade spark-redis version which depend on scala-2.12

## How was this patch tested?

