### PR TITLE
Fix ArrayIndexOutOfBoundsException in BufferReader

### DIFF
--- a/emr-oss/src/main/java/com/aliyun/fs/oss/nat/BufferReader.java
+++ b/emr-oss/src/main/java/com/aliyun/fs/oss/nat/BufferReader.java
@@ -92,14 +92,17 @@ public class BufferReader {
         this.bufferSize = (int) Math.pow(2, power);
       }
 
-      if (buffer == null) {
-        buffer = new byte[bufferSize];
-      }
       this.concurrentStreams = conf.getInt("fs.oss.reader.concurrent.number", 4);
       if ((Math.log(concurrentStreams) / Math.log(2)) != 0) {
         int power = (int) Math.ceil(Math.log(concurrentStreams) / Math.log(2));
         this.concurrentStreams = (int) Math.pow(2, power);
       }
+
+      if (buffer == null) {
+        // The last half-1 of the last reader may exceed splitSize, so allocate (concurrentStreams - 1) more bytes to avoid the ArrayIndexOutOfBoundsException
+        buffer = new byte[bufferSize + concurrentStreams - 1];
+      }
+
       this.readers = new ConcurrentReader[concurrentStreams];
       this.splitContentSize = new int[concurrentStreams * 2];
       this.splitSize = bufferSize / concurrentStreams / 2;


### PR DESCRIPTION
## What changes were proposed in this pull request?

The last half-1 of the last reader will trigger the ArrayIndexOutOfBoundsException under a certain file size.

eg: file size: 33554430B, it is equal to 32MB minus two bytes.

In the default configuration, version 1 algorithm is used, lengthToFetch = 33554430, bufferSize = 2097152 = 2MB, concurrentStreams = 4, splitSize = 262144.

```
-------------------------- buffer --------------------------
r0h0    r1h0    r2h0    r3h0    r0h1    r1h1    r2h1    r3h1
-------------------------- buffer --------------------------
```

When reader-3 reads the last half-1, it will enter the last else if block in the fetchData method, fetchLength will be calculated at this time.

For reader-0 and reader-1 and reader-2:
fetchLength = (int) (lengthToFetch - (long) halfFetched * bufferSize / 2) / concurrentStreams = 33554430 - 31 * 2097152 / 2 = 1048574 / 4 = 262143.5 = 262143;

For reader-3:
fetchLength = (int) (lengthToFetch - (long) halfFetched * bufferSize / 2 - (fetchLength * (concurrentStreams - 1))) = 33554430 - 31 * 2097152 / 2 - (262143 * (4 - 1)) = 262145.

At this time fetchLength is greater than splitSize. Because the undivisible part needs to be cached by reader-3, the pre-allocated buffer is exceeded. In the read loop call of the do while block, ArrayIndexOutOfBoundsException is thrown, the main thread's read method will keep looping sleep...

```
java.io.IOException: java.lang.ArrayIndexOutOfBoundsException: length == 254461 off == 1842692 buffer length == 2097152
	at com.aliyun.fs.oss.nat.BufferReader$ConcurrentReader.fetchData(BufferReader.java:575)
	at com.aliyun.fs.oss.nat.BufferReader$ConcurrentReader.execute(BufferReader.java:479)
	at com.aliyun.fs.oss.utils.Task.run(Task.java:43)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: java.lang.ArrayIndexOutOfBoundsException: length == 254461 off == 1842692 buffer length == 2097152
	at java.net.SocketInputStream.read(SocketInputStream.java:162)
	at java.net.SocketInputStream.read(SocketInputStream.java:141)
	at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:139)
	at org.apache.http.impl.io.SessionInputBufferImpl.read(SessionInputBufferImpl.java:200)
	at org.apache.http.impl.io.ContentLengthInputStream.read(ContentLengthInputStream.java:178)
	at org.apache.http.conn.EofSensorInputStream.read(EofSensorInputStream.java:137)
	at java.util.zip.CheckedInputStream.read(CheckedInputStream.java:82)
	at java.io.FilterInputStream.read(FilterInputStream.java:133)
	at com.aliyun.oss.event.ProgressInputStream.read(ProgressInputStream.java:118)
	at java.util.zip.CheckedInputStream.read(CheckedInputStream.java:82)
	at com.aliyun.fs.oss.nat.BufferReader$ConcurrentReader.fetchData(BufferReader.java:561)
	... 5 more
```

Therefore, I think that allocate (concurrentStreams - 1) more bytes for the buffer is the easiest way to fix it. The problem is caused by the indivisible space. Otherwise, the design of the buffer may need to be adjusted.

## How was this patch tested?

Added unit test: com.aliyun.fs.oss.TestAliyunOSSInputStream#testArrayIndexOutOfBoundsException